### PR TITLE
Remove double Image import because its pointless

### DIFF
--- a/procgame/dmd/animation.py
+++ b/procgame/dmd/animation.py
@@ -5,7 +5,6 @@ import sqlite3
 import bz2
 import StringIO
 import time
-import Image
 from procgame.dmd import Frame
 from procgame import config
 import logging


### PR DESCRIPTION
Compy's original commit message: It also breaks things on systems without PIL despite trying to make it gracefully handle not having the library installed.

tomlogic's additional comment: Note that I needed this commit in my master to build on a Windows 7 machine without the extra PIL/Pillow/whatever libraries installed.  Trivial fix and a missing piece of the commit that wrapped the import in a try/except.